### PR TITLE
Fix Ubuntu compatibility problems

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,7 @@ Standards-Version: 3.7.3
 
 Package: pkg-cacher
 Architecture: all
-#Depends: ${perl:Depends}, bzip2, libwww-curl-perl (>=3.12), libwww-perl, libdigest-sha1-perl, ed
-Depends: ${perl:Depends}, bzip2, libwww-curl-perl, libwww-perl, libdigest-sha1-perl, ed
+Depends: ${perl:Depends}, bzip2, libwww-curl-perl, libwww-perl, libdigest-sha-perl, ed
 Suggests: libio-socket-inet6-perl
 Description: Caching proxy for Debian, Ubuntu, RedHat, Fedora, and CentOS repositories.
  Pkg-cacher performs caching of packages and metadata which have been downloaded by 

--- a/debian/pkg-cacher-sa.postinst
+++ b/debian/pkg-cacher-sa.postinst
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # postinst script for pkg-cacher
 #
 # see: dh_installdeb(1)

--- a/pkg-cacher-cleanup.pl
+++ b/pkg-cacher-cleanup.pl
@@ -25,7 +25,7 @@ use Cwd;
 
 use Fcntl qw/:DEFAULT :flock F_SETFD/;
 use Getopt::Long qw(:config no_ignore_case bundling pass_through);
-use Digest::SHA1;
+use Digest::SHA;
 use HTTP::Date;
 
 my $configfile = '/etc/pkg-cacher/pkg-cacher.conf';
@@ -204,7 +204,7 @@ sub pdiff {
 	return;
     }
 
-    my $sha1 = Digest::SHA1->new;
+    my $sha1 = Digest::SHA->new;
     my $digest;
 
     # Check size first
@@ -682,7 +682,7 @@ for(<*.deb>, <*.udeb>, <*.bz2>, <*.gz>, <*.dsc>) {
 #	    print "Validating SHA1 $target_sum for $_\n";
 	    open(my $fh, $_) || die "Unable to open file $_ to verify checksum: $!";
 	    flock($fh, LOCK_EX);
-	    if (Digest::SHA1->new->addfile(*$fh)->hexdigest ne $target_sum) {
+	    if (Digest::SHA->new->addfile(*$fh)->hexdigest ne $target_sum) {
 		unlink $_, "../headers/$_", "../private/$_.complete" unless $sim_mode;
 		printmsg "Checksum mismatch: $_, removing\n";
 	    }


### PR DESCRIPTION
Specify /bin/bash instead of /bin/sh since it is actually dash.

Use Digest::SHA instead of Digest:SHA1, Digest::SHA1 is obsolete and not available on Ubuntu.

Thanks to Brian J. Murrell for the fixes.
