### PR TITLE
Add chunked transfer support and retry after malformed responses

### DIFF
--- a/pkg-cacher
+++ b/pkg-cacher
@@ -31,7 +31,7 @@ use File::Path;
 require 'pkg-cacher-lib.pl';
 
 # Set some defaults
-my $version="0.1";
+our $version="1.0.0-1";
 my $configfile_default = '/etc/pkg-cacher/pkg-cacher.conf';
 
 our $configfile = $configfile_default;


### PR DESCRIPTION
If a server downloads using chunked transfers there is no Content-Length
so manufacture one.

Some Fedora mirrors using nginx are returning bogus responses without
the proper response headers causes failures.  Ignore them and retry up
to five times.

Ignore body callbacks on HEAD requests, they are usually html formatted
error messages from broken nginx mirrors.

Fix version in User-Agent header.
