### PR TITLE
Remove 'our' to restore perl-5.18 compatibility

### DIFF
--- a/pkg-cacher
+++ b/pkg-cacher
@@ -265,12 +265,12 @@ sub debug_message {
 	}
 }
 
-our sub info_message {
+sub info_message {
 	my $message = shift;
 	writeerrorlog("info [$$]: $message");
 }
 
-our sub error_message {
+sub error_message {
 	my $message = shift;
 	writeerrorlog("error [$$]: $message");
 }


### PR DESCRIPTION
  When running pkg-cacher with perl-5.18 there is an error:
  "Experimental "our" subs not enabled at /usr/share/pkg-cacher/pkg-cacher line 268."
  Fixes issue #29
