### PR TITLE
Add support for el7 repositories

### DIFF
--- a/index_files.regexp
+++ b/index_files.regexp
@@ -10,13 +10,17 @@ Contents-.+\.gz
 \d{4}-\d{2}-\d{2}-\d{4}\.\d+\.gz
 # Redhat files
 ([[:xdigit:]]+-)?comps.*\.xml(\.gz)?
+([[:xdigit:]]+-)?comps.*\.xml(\.xz)?
 ([[:xdigit:]]+-)?filelists\.sqlite\.bz2
+([[:xdigit:]]+-)?filelists\.sqlite\.xz
 ([[:xdigit:]]+-)?filelists\.xml\.gz
 ([[:xdigit:]]+-)?other\.sqlite\.bz2
+([[:xdigit:]]+-)?other\.sqlite\.xz
 ([[:xdigit:]]+-)?other\.xml\.gz
 ([[:xdigit:]]+-)?pkgtags\.sqlite\.gz
 ([[:xdigit:]]+-)?prestodelta\.xml\.gz
 ([[:xdigit:]]+-)?primary\.sqlite\.bz2
+([[:xdigit:]]+-)?primary\.sqlite\.xz
 ([[:xdigit:]]+-)?primary\.xml\.gz
 repomd\.xml
 updateinfo\.xml\.gz

--- a/index_files.regexp
+++ b/index_files.regexp
@@ -20,6 +20,8 @@ Contents-.+\.gz
 ([[:xdigit:]]+-)?primary\.xml\.gz
 repomd\.xml
 updateinfo\.xml\.gz
+treeinfo
+\.treeinfo
 # OpenSuSE files
 EXTRA_PROV
 MD5SUMS


### PR DESCRIPTION
Hi.

I only noticed a few days ago, that also the Repos.pm needs to be adjusted for properly handle the xz cleanup. Without it this pull request doesn't make so much sense. As you implemented xz support before but removed it again due to the missing dependencies on Debian stable and CentOS 5/6 you might also want to ignore this pull request then. 

Or you might want to add my 'unxz' branch to a separated branch of yours, so ppl who are using the latest versions of their distributions still can enjoy pkg-cacher. The branch contains the reverted xz/lzma removal commit as well as the updated index_files.regexp for EL7 and I further added the dependencies to the control and spec files.

Sorry for all the noise...
Cheers, ganto
