### PR TITLE
Remove HTTP header whitespace requirement

### DIFF
--- a/pkg-cacher-request.pl
+++ b/pkg-cacher-request.pl
@@ -95,7 +95,7 @@ sub sa_get_request {
 				}
 			} elsif (/^Host:\s+(\S+)/) {
 				$$request_data_ref{'hostreq'} = $1;
-			} elsif (/^((?:Pragma|Cache-Control):\s+\S+)/) {
+			} elsif (/^((?:Pragma|Cache-Control):\s*\S+)/) {
 				debug_message("Request specified $1");
 				push @cache_control, $1;
 				if ($1=~/no-cache/) {


### PR DESCRIPTION
Fixes #35

pkg-cacher is expecting a space after the : in the HTTP headers, but that is not a requirement according to https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html where it says:

The field value MAY be preceded by any amount of LWS, though a single SP is preferred
(emphasis from original)